### PR TITLE
Fix cookie expire typo

### DIFF
--- a/README.md
+++ b/README.md
@@ -144,7 +144,7 @@ key - cookie key for storing authentication headers for persistence, default: 'a
 
 path - cookie path, default: '/'
 
-expire - cookie expiration in days, default: 14
+expires - cookie expiration in days, default: 14
 
 ### tokenFormat
 authentication data structure, which is going back and forth between backend and client

--- a/src/actions/headers.js
+++ b/src/actions/headers.js
@@ -8,7 +8,7 @@ export function updateHeaders(headers = {}) {
     const { cookieOptions } = getSettings(getState());
 
     Cookies.set(cookieOptions.key, JSON.stringify(headers), {
-      expires: cookieOptions.expires,
+      expires: cookieOptions.expire,
       path: cookieOptions.path
     });
 

--- a/src/actions/headers.js
+++ b/src/actions/headers.js
@@ -8,7 +8,7 @@ export function updateHeaders(headers = {}) {
     const { cookieOptions } = getSettings(getState());
 
     Cookies.set(cookieOptions.key, JSON.stringify(headers), {
-      expires: cookieOptions.expire,
+      expires: cookieOptions.expires,
       path: cookieOptions.path
     });
 

--- a/src/defaults/cookieOptions.js
+++ b/src/defaults/cookieOptions.js
@@ -1,5 +1,5 @@
 export default {
   key: 'authHeaders',
   path: '/',
-  expire: 14
+  expires: 14
 };


### PR DESCRIPTION
Small typo when set expire cookie time.

Now workaround is redeclare cockieOptions as 
cookieOptions: {
    key: 'authHeaders',
    path: '/',
    expires: 14,
  },