### PR TITLE
Update headers after sign_out response

### DIFF
--- a/src/actions/signOut.js
+++ b/src/actions/signOut.js
@@ -25,9 +25,9 @@ export function signOut() {
     const { backend } = getSettings(getState());
 
     dispatch(signOutStart());
-    dispatch(updateHeaders());
 
     if (!backend.signOutPath) {
+      dispatch(updateHeaders());
       dispatch(signOutComplete());
 
       return Promise.resolve();
@@ -36,11 +36,13 @@ export function signOut() {
     return dispatch(fetch(backend.signOutPath, { method: 'delete' }))
       .then(parseResponse)
       .then(() => {
+        dispatch(updateHeaders());
         dispatch(signOutComplete());
 
         return Promise.resolve();
       })
       .catch((er) => {
+        dispatch(updateHeaders());
         dispatch(signOutError(er));
 
         return Promise.reject(er);


### PR DESCRIPTION
I'm not sure is it right workflow, but it might be useful when sign_out request contains our headers for backend delete it. 
How do you think? 